### PR TITLE
Add a 'waitforcert' parameter to the puppet_certificate type

### DIFF
--- a/lib/puppet/type/puppet_certificate.rb
+++ b/lib/puppet/type/puppet_certificate.rb
@@ -1,5 +1,3 @@
-require 'puppet/face'
-
 Puppet::Type.newtype(:puppet_certificate) do
   @doc = "Manage Puppet certificates"
   desc <<-EOT
@@ -20,6 +18,10 @@ Puppet::Type.newtype(:puppet_certificate) do
 
   newparam(:ca_server) do
     desc "The certificate authority to use"
+  end
+
+  newparam(:waitforcert) do
+    desc "The amount of time to wait for the certificate to be signed"
   end
 
   newproperty(:dns_alt_names, :array_matching => :all) do


### PR DESCRIPTION
Previously, the certificate type would fail immediately if a
certificate request was not already signed, necessitating a second run
of puppet once the signing had occured. With this change, it is now
possible to have the puppet run block and wait for the certificate to
be signed out-of-band before continuing.

This isn't super-clean, but it works.
