### PR TITLE
Big refactor and make it work with Puppet 6 and 7

### DIFF
--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -43,10 +43,10 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
         timeout = @resource[:waitforcert].to_i
       end
 
-      return if get_certificate(certname)
+      cert = get_certificate(certname)
 
-      if timeout != 0
-        alert(<<-EOL.gsub(/\s+/, " ").strip)
+      if cert.nil? && timeout != 0
+        notice(<<-EOL.gsub(/\s+/, " ").strip)
           Waiting #{timeout} seconds for #{certname} to be signed. Please
           sign this certificate on the CA host or use the Request Manager
           in the Puppet Enterprise Console.

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'puppet/face'
+require 'puppet/ssl/certificate'
 
 Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   desc "Manage Puppet certificates using the certificate face"
@@ -238,10 +239,13 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   end
 
   def get_certificate(certname)
-    Puppet::Rest::Routes.get_certificate(
-      certname,
-      Puppet::SSL::SSLContext.new(store: ssl_store)
-    )
+    return nil unless @certificate = Puppet::SSL::Certificate.indirection.find(certname)
+    @certificate
+    # Puppet::Rest no longer in Puppet 5.5+
+    # Puppet::Rest::Routes.get_certificate(
+    #   certname,
+    #   Puppet::SSL::SSLContext.new(store: ssl_store)
+    # )
   end
 
   def debug(msg)

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -177,6 +177,8 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   def key
     @cert_provider = Puppet::X509::CertProvider.new
     @key ||= @cert_provider.load_private_key(@resource[:name])
+  rescue => e
+    @key ||= Puppet::SSL::Key.indirection.find(@resource[:name])
   end
 
   def certificate
@@ -242,6 +244,11 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
 
   def use_crl_chain?
     @crl_usage == true || @crl_usage == :chain
+  end
+
+  def get_certificate(certname)
+    return nil unless @certificate = Puppet::SSL::Certificate.indirection.find(certname)
+    @certificate
   end
 
   def download_cert(ssl_context)

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
     unless key
       debug "generating new key for #{@resource[:name]}"
       ensure_cadir if ca_location == 'local'
-      Puppet::SSL::Oids.register_puppet_oids
+      Puppet::SSL::Oids.register_puppet_oids if Puppet::SSL::Oids.respond_to?('register_puppet_oids')
       host = Puppet::SSL::Host.new(@resource[:name])
       host.generate_certificate_request(:dns_alt_names => options[:dns_alt_names])
     end

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -177,7 +177,11 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   def key
     @cert_provider = Puppet::X509::CertProvider.new
     @key ||= @cert_provider.load_private_key(@resource[:name])
-  rescue => e
+  rescue NameError
+    # Older versions of Puppet (before 6.4?) don't have Puppet::X509
+    # so use the old way of getting the key.
+    # Not tested, but presumably this means versions 6.x before 6.4
+    # aren't going to work right now??
     @key ||= Puppet::SSL::Key.indirection.find(@resource[:name])
   end
 
@@ -244,11 +248,6 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
 
   def use_crl_chain?
     @crl_usage == true || @crl_usage == :chain
-  end
-
-  def get_certificate(certname)
-    return nil unless @certificate = Puppet::SSL::Certificate.indirection.find(certname)
-    @certificate
   end
 
   def download_cert(ssl_context)

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -3,131 +3,189 @@ require 'puppet/face'
 require 'puppet/ssl/certificate'
 
 Puppet::Type.type(:puppet_certificate).provide(:ruby) do
-  desc "Manage Puppet certificates using the certificate face"
+  desc 'Manage Puppet certificates'
+
+  def initialize(value = {})
+    super(value)
+    if at_least_puppet6
+      @cert_provider = Puppet::X509::CertProvider.new(hostprivkey: nil, hostcert: nil)
+      @machine = Puppet::SSL::StateMachine.new
+    else
+      debug('using legacy code and APIs')
+    end
+  end
 
   def create
     debug "create #{@resource[:name]}"
-    generate_csr
-    if ca_location == 'local'
-      sign_certificate
+    submit_csr
+    sign_certificate if @resource[:ca_location] == :local
+    retrieve_certificate
+  end
+
+  def submit_csr
+    debug "generating new key for #{@resource[:name]} and submitting csr"
+    ensure_cadir if @resource[:ca_location] == :local
+    Puppet::SSL::Oids.register_puppet_oids if Puppet::SSL::Oids.respond_to?('register_puppet_oids')
+
+    if at_least_puppet6
+      key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+      @cert_provider.save_private_key(@resource[:name], key)
+
+      csr = create_request(key)
+      ssl_context = @machine.ensure_ca_certificates
+      route = create_route(ssl_context)
+      begin
+        route.put_certificate_request(@resource[:name], csr, ssl_context: ssl_context)
+      rescue Puppet::HTTP::ResponseError => e
+        if e.response.code == 400
+          raise Puppet::Error.new(_("Could not submit certificate request for '%{name}' to %{url} due to a conflict on the server") % { name: @resource[:name], url: route.url }, e)
+        end
+
+        raise Puppet::Error.new(_('Failed to submit certificate request: %{message}') % { message: e.message  }, e)
+      rescue StandardError => e
+        raise Puppet::Error.new(_('Failed to submit certificate request: %{message}') % { message: e.message  }, e)
+      end
+      @cert_provider.save_request(@resource[:name], csr)
+      Puppet.notice(_("Submitted certificate request for '%{name}' to %{url}") % { name: @resource[:name], url: route.url })
     else
-      retrieve_certificate
+      host = Puppet::SSL::Host.new(@resource[:name])
+      if @resource[:dns_alt_names]
+        host.generate_certificate_request(:dns_alt_names => @resource[:dns_alt_names].join(','))
+      else
+        host.generate_certificate_request
+      end
     end
   end
 
-  def generate_csr
-    unless key
-      debug "generating new key for #{@resource[:name]}"
-      ensure_cadir if ca_location == 'local'
-      Puppet::SSL::Oids.register_puppet_oids if Puppet::SSL::Oids.respond_to?('register_puppet_oids')
-      host = Puppet::SSL::Host.new(@resource[:name])
-      host.generate_certificate_request(:dns_alt_names => options[:dns_alt_names])
+  def create_request(key)
+    options = {}
+    # csr_attributes could maybe become part of the type instead??
+    csr_attributes = Puppet::SSL::CertificateRequestAttributes.new(Puppet[:csr_attributes])
+
+    if csr_attributes.load
+      options[:csr_attributes] = csr_attributes.custom_attributes
+      options[:extension_requests] = csr_attributes.extension_requests
     end
+
+    options[:dns_alt_names] = @resource[:dns_alt_names].join(',') if @resource[:dns_alt_names]
+
+    csr = Puppet::SSL::CertificateRequest.new((@resource[:name]))
+    csr.generate(key, options)
   end
 
   def retrieve_certificate
-    unless certificate
-      @machine = Puppet::SSL::StateMachine.new
+    timeout = 0
+    certname = @resource[:name]
+    debug "retrieving certificate for #{certname}"
+    timeout = @resource[:waitforcert].to_i if @resource[:waitforcert]
+
+    if at_least_puppet6
       ssl_context = @machine.ensure_ca_certificates
-
-      timeout = 0
-      certname = @resource[:name]
-      debug "retrieving certificate for #{certname}"
-      if @resource[:waitforcert]
-        timeout = @resource[:waitforcert].to_i
-      end
-
       cert = download_cert(ssl_context)
+    else
+      cert = certificate # No really, the indirection stuff we use also tries to download the cert from the CA
+    end
 
-      if cert.nil? && timeout != 0
-        notice(<<-EOL.gsub(/\s+/, " ").strip)
-          Waiting #{timeout} seconds for #{certname} to be signed. Please
-          sign this certificate on the CA host or use the Request Manager
-          in the Puppet Enterprise Console.
-        EOL
-
-        while timeout > 0 && cert.nil?
-          cert = download_cert(ssl_context)
-          sleep 2 # trying every second might be a bit too rapid?
-          timeout -= 1
-        end
-      end
-
-      # If a cert didn't result then fail verbosely
-      fail(<<-EOL.gsub(/\s+/, " ").strip) unless cert
-        unable to retrieve certificate for #{@resource[:name]}. You may need
-        to sign this certificate on the CA host by running `puppet certificate
-        sign #{@resource[:name]} --ca-location=local --mode=master`
+    if cert.nil? && timeout != 0
+      notice(<<-EOL.gsub(/\s+/, " ").strip)
+        Waiting #{timeout} seconds for #{certname} to be signed. Please
+        sign this certificate on the CA host or use the Request Manager
+        in the Puppet Enterprise Console.
       EOL
 
-      @ssl_provider = Puppet::SSL::SSLProvider.new
-      @cert_provider = Puppet::X509::CertProvider.new
-      @ssl_provider.create_context(
-        cacerts: ssl_context.cacerts,
-        crls: ssl_context.crls,
-        private_key: key,
-        client_cert: cert
-      )
+      while timeout > 0 && cert.nil?
+        cert = if at_least_puppet6
+                 download_cert(ssl_context)
+               else
+                 certificate
+               end
+        sleep 2 # trying every second might be a bit too rapid?
+        timeout -= 1
+      end
+    end
+
+    # If a cert didn't result then fail verbosely
+    unless cert
+      raise Puppet::Error, "Unable to retrieve certificate for #{@resource[:name]}. You may need to sign this certificate on the CA host by running `puppetserver ca sign --cert #{@resource[:name]}`"
+    end
+
+    if at_least_puppet6
       @cert_provider.save_client_cert(@resource[:name], cert)
       @cert_provider.delete_request(@resource[:name])
+    else
+      delete_file(File.join(Puppet[:requestdir], "#{@resource[:name].downcase}.pem"))
     end
   end
 
-  def sign_certificate
-    unless certificate
-      debug "signing certificate for #{@resource[:name]}"
-      opts = options.merge(:allow_dns_alt_names => true)
-      # Do it oldskool.
-      ca = Puppet::SSL::CertificateAuthority.new
-      interface = Puppet::SSL::CertificateAuthority::Interface.new(
-        :sign,
-        opts.merge({:to => [@resource[:name]]})
-      )
-      ensure_cadir
-      cert = interface.sign(ca)
-
-      # If a cert didn't result then fail verbosely
-      fail(<<-EOL.gsub(/\s+/, " ").strip) unless cert
-        unable to sign certificate for #{@resource[:name]}
-      EOL
+  def download_cert(ssl_context)
+    route = create_route(ssl_context)
+    Puppet.info _("Downloading certificate '%{name}' from %{url}") % { name: @resource[:name], url: route.url }
+    _, x509 = route.get_certificate(@resource[:name], ssl_context: ssl_context)
+    cert = OpenSSL::X509::Certificate.new(x509)
+    Puppet.notice _("Downloaded certificate '%{name}' with fingerprint %{fingerprint}") % { name: @resource[:name], fingerprint: fingerprint(cert) }
+    cert
+  rescue Puppet::HTTP::ResponseError => e
+    unless e.response.code == 404
+      raise Puppet::Error.new(_('Failed to download certificate: %{message}') % { message: e.message }, e)
     end
+  rescue StandardError => e
+    raise Puppet::Error.new(_('Failed to download certificate: %{message}') % { message: e.message }, e)
+  end
+
+  def sign_certificate
+    debug "signing certificate for #{@resource[:name]}"
+
+    req = Net::HTTP::Put.new("/puppet-ca/v1/certificate_status/#{@resource[:name]}", { 'Content-Type' => 'application/json' })
+    req.body = JSON.dump({ desired_state: 'signed' })
+    https = Net::HTTP.new(Puppet.settings[:ca_server], Puppet.settings[:ca_port])
+    https.use_ssl = true
+    https.cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
+    https.key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
+    https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    https.ca_file = Puppet.settings[:localcacert]
+    resp = https.start { |cx| cx.request(req) }
+    warning "failed to sign certificate: #{resp.body}" if resp.code_type != Net::HTTPNoContent
   end
 
   def ensure_cadir
     # This makes everything "just work" even on systems without a cadir yet
     cadir = Puppet.settings[:cadir]
-    if not File.exists?(cadir)
-      FileUtils.mkdir_p(File.join(cadir, 'requests'), :mode => 0750)
-      FileUtils.chown_R(Puppet.settings[:user], Puppet.settings[:group], cadir)
-    end
+    return if File.exists?(cadir)
+
+    FileUtils.mkdir_p(File.join(cadir, 'requests'), :mode => 0750)
+    FileUtils.chown_R(Puppet.settings[:user], Puppet.settings[:group], cadir)
   end
 
   def clean
-      debug "cleaning #{@resource[:name]} on ca"
-      req = Net::HTTP::Delete.new("/puppet-ca/v1/certificate_status/#{@resource[:name]}")
-      https = Net::HTTP.new(Puppet.settings[:ca_server], Puppet.settings[:ca_port])
-      https.use_ssl = true
-      https.cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
-      https.key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
-      https.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      https.ca_file = Puppet.settings[:localcacert]
-      resp = https.start { |cx| cx.request(req) }
-      if resp.code_type != Net::HTTPNoContent
-          warning "failed to clean certificate: #{resp.body}"
-      end
+    debug "cleaning #{@resource[:name]} on ca"
+    req = Net::HTTP::Delete.new("/puppet-ca/v1/certificate_status/#{@resource[:name]}")
+    https = Net::HTTP.new(Puppet.settings[:ca_server], Puppet.settings[:ca_port])
+    https.use_ssl = true
+    https.cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
+    https.key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
+    https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    https.ca_file = Puppet.settings[:localcacert]
+    resp = https.start { |cx| cx.request(req) }
+    warning "failed to clean certificate: #{resp.body}" if resp.code_type != Net::HTTPNoContent
   end
 
   def destroy
-    if @resource[:clean]
-        clean
-    end
+    clean if @resource[:clean] == :true
 
-    Puppet::SSL::Key.indirection.destroy(@resource[:name])
+    filename = "#{@resource[:name].downcase}.pem"
+
+    delete_file(File.join(Puppet[:privatekeydir], filename))
     @key = nil
-    Puppet::SSL::Certificate.indirection.destroy(@resource[:name])
+    delete_file(File.join(Puppet[:certdir], filename))
     @certificate = nil
-    Puppet::SSL::CertificateRequest.indirection.destroy(@resource[:name])
-    @csr = nil
+    delete_file(File.join(Puppet[:requestdir], filename), false)
+  end
+
+  def delete_file(path, warn = true)
+    debug("deleting #{path}")
+    Puppet::FileSystem.unlink(path)
+  rescue Errno::ENOENT
+    warning("file not found when trying to delete #{path}") if warn
   end
 
   def exists?
@@ -148,127 +206,39 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
     # not implemented
   end
 
-  def ca_location
-    @ca_location ||= begin
-      if @resource[:ca_location]
-        @resource[:ca_location]
-      else
-        case Puppet.settings[:ca_server]
-        when Facter.value('fqdn'), Facter.value('hostname')
-          'local'
-        else
-          'remote'
-        end
-      end
-    end
-  end
-
-  def options
-    @options ||= begin
-      options = {}
-      options[:ca_location] = ca_location
-      if @resource[:dns_alt_names]
-        options[:dns_alt_names] = @resource[:dns_alt_names].join(',')
-      end
-      options
-    end
-  end
-
   def key
-    @cert_provider = Puppet::X509::CertProvider.new
-    @key ||= @cert_provider.load_private_key(@resource[:name])
-  rescue NameError
-    # Older versions of Puppet (before 6.4?) don't have Puppet::X509
-    # so use the old way of getting the key.
-    # Not tested, but presumably this means versions 6.x before 6.4
-    # aren't going to work right now??
-    @key ||= Puppet::SSL::Key.indirection.find(@resource[:name])
+    if at_least_puppet6
+      debug("Attempting to load key for #{@resource[:name]}")
+      @key ||= @cert_provider.load_private_key(@resource[:name])
+    else
+      @key ||= Puppet::SSL::Key.indirection.find(@resource[:name])
+    end
   end
 
   def certificate
-    @certificate ||= Puppet::SSL::Certificate.indirection.find(@resource[:name])
-  end
-
-  def csr
-    @csr ||= begin
-      @csr = Puppet::SSL::CertificateRequest.indirection.find(@resource[:name])
-      unless @csr
-        @csr = Puppet::SSL::CertificateRequest.new(@resource[:name])
-        @csr.generate(key.content, options)
+    if at_least_puppet6
+      debug("Attempting to load cert for #{@resource[:name]}") unless @certificate
+      @certificate ||= @cert_provider.load_client_cert(@resource[:name])
+    else
+      if (cert = Puppet::SSL::Certificate.indirection.find(@resource[:name]))
+        @certificate ||= cert.content
       end
-      @csr
     end
   end
 
   def is_valid?
-      unless certificate.nil?
-          grace_time = @resource[:renewal_grace_period] * 60 * 60 * 24
-          certificate.content.not_after - grace_time > Time.now
-      end
-  end
+    return if certificate.nil?
 
-  # Create/return a store that uses our SSL info to validate
-  # connections.
-  def ssl_store(purpose = OpenSSL::X509::PURPOSE_ANY)
-    if @ssl_store.nil?
-      @ssl_store = build_ssl_store(purpose)
-    end
-    @ssl_store
-  end
-
-  def build_ssl_store(purpose=OpenSSL::X509::PURPOSE_ANY)
-    store = OpenSSL::X509::Store.new
-    store.purpose = purpose
-
-    # Use the file path here, because we don't want to cause
-    # a lookup in the middle of setting our ssl connection.
-    store.add_file(Puppet.settings[:localcacert])
-
-    if use_crl?
-      if !Puppet::FileSystem.exist?(crl_path)
-        download_and_save_crl_bundle(store)
-      end
-
-      crls = load_crls(crl_path)
-
-      flags = OpenSSL::X509::V_FLAG_CRL_CHECK
-      if use_crl_chain?
-        flags |= OpenSSL::X509::V_FLAG_CRL_CHECK_ALL
-      end
-
-      store.flags = flags
-      crls.each {|crl| store.add_crl(crl) }
-    end
-    store
-  end
-
-  def use_crl?
-    !!@crl_usage
-  end
-
-  def use_crl_chain?
-    @crl_usage == true || @crl_usage == :chain
-  end
-
-  def download_cert(ssl_context)
-    route = create_route(ssl_context)
-    Puppet.info _("Downloading certificate '%{name}' from %{url}") % { name: @resource[:name], url: route.url }
-    _, x509 = route.get_certificate(@resource[:name], ssl_context: ssl_context)
-    cert = OpenSSL::X509::Certificate.new(x509)
-    Puppet.notice _("Downloaded certificate '%{name}' with fingerprint %{fingerprint}") % { name: @resource[:name], fingerprint: fingerprint(cert) }
-    cert
-  rescue Puppet::HTTP::ResponseError => e
-    if e.response.code == 404
-      return nil
-    else
-      raise Puppet::Error.new(_("Failed to download certificate: %{message}") % { message: e.message }, e)
-    end
-  rescue => e
-    raise Puppet::Error.new(_("Failed to download certificate: %{message}") % { message: e.message }, e)
+    grace_time = @resource[:renewal_grace_period] * 60 * 60 * 24
+    certificate.not_after - grace_time > Time.now
   end
 
   def debug(msg)
     Puppet.debug "puppet_certificate: #{msg}"
+  end
+
+  def warning(msg)
+    Puppet.warning "puppet_certificate: #{msg}"
   end
 
   def fingerprint(cert)
@@ -279,4 +249,14 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
     Puppet.runtime[:http].create_session.route_to(:ca, ssl_context: ssl_context)
   end
 
+  def at_least_puppet6
+    version = Gem::Version.new(Puppet.version)
+
+    # The replacement APIs were only introduced in Puppet 6.4
+    if version >= Gem::Version.new('6.0.0') && version < Gem::Version.new('6.4.0')
+      raise Puppet::Error, "#{Puppet.version} is not supported by the `puppet_certificate` type."
+    end
+
+    version >= Gem::Version.new('6.4.0')
+  end
 end

--- a/lib/puppet/provider/puppet_certificate/ruby.rb
+++ b/lib/puppet/provider/puppet_certificate/ruby.rb
@@ -262,7 +262,7 @@ Puppet::Type.type(:puppet_certificate).provide(:ruby) do
   end
 
   def debug(msg)
-    debug "puppet_certificate: #{msg}"
+    Puppet.debug "puppet_certificate: #{msg}"
   end
 
   def fingerprint(cert)

--- a/lib/puppet/type/puppet_certificate.rb
+++ b/lib/puppet/type/puppet_certificate.rb
@@ -1,64 +1,69 @@
 Puppet::Type.newtype(:puppet_certificate) do
-  @doc = "Manage Puppet certificates"
+  @doc = 'Manage Puppet certificates'
   desc <<-EOT
     Ensures that a given Puppet certificate exists or does not exist.
   EOT
 
   ensurable do
-      desc "Create or remove the Puppet certificate"
-      defaultvalues
-      block if block_given?
+    desc 'Create or remove the Puppet certificate'
+    defaultvalues
+    block if block_given?
 
-      newvalue(:valid) do
-          if provider.exists?
-              if provider.is_valid?
-                  if @resource.property(:dns_alt_names)
-                      @resource.property(:dns_alt_names).sync
-                  end
-              else
-                  provider.destroy
-                  provider.create
-              end
-          else
-              provider.create
+    newvalue(:valid) do
+      if provider.exists?
+        if provider.is_valid?
+          if @resource.property(:dns_alt_names)
+            @resource.property(:dns_alt_names).sync
           end
+        else
+          provider.destroy
+          provider.create
+        end
+      else
+        provider.create
       end
+    end
 
-      def insync?(is)
-          return true if should == :valid and provider.is_valid?
-          super
-      end
+    def insync?(is)
+      return true if should == :valid and provider.is_valid?
+      super
+    end
   end
 
   newparam(:name) do
+    desc 'The certificate name'
     isnamevar
     isrequired
-    desc "The certificate name"
   end
 
   newparam(:ca_location) do
-    desc "The location of the certificate authority (local or remote)"
+    desc 'The location of the certificate authority (local or remote)'
+    newvalues(:local, :remote)
+
+    defaultto :remote
   end
 
   newparam(:ca_server) do
-    desc "The certificate authority to use"
+    # UNIMPLEMENTED
+    desc 'The certificate authority to use'
   end
 
   newparam(:waitforcert) do
-    desc "The amount of time to wait for the certificate to be signed"
+    desc 'The amount of time to wait for the certificate to be signed'
   end
 
   newparam(:renewal_grace_period) do
-    desc "The number of days before expiration the certificate should be renewed"
+    desc 'The number of days before expiration the certificate should be renewed'
     munge do |v|
-        Integer(v)
+      Integer(v)
     end
     defaultto(0)
   end
 
-  newparam(:clean, :boolean => true) do
-    desc "Delete the certificate from the CA before removing it locally."
+  newparam(:clean) do
+    desc 'Delete the certificate from the CA before removing it locally.'
 
+    newvalues(:true, :false)
     defaultto :false
   end
 
@@ -70,12 +75,11 @@ Puppet::Type.newtype(:puppet_certificate) do
   end
 
   newproperty(:dns_alt_names, :array_matching => :all) do
-    desc "Alternate DNS names by which the certificate holder may be reached"
+    desc 'Alternate DNS names by which the certificate holder may be reached'
   end
 
   def refresh
-    if [:present, :valid].include?(@parameters[:ensure].value) &&
-      @parameters[:onrefresh].value == :regenerate
+    if [:present, :valid].include?(@parameters[:ensure].value) && @parameters[:onrefresh].value == :regenerate
 
       provider.destroy
       provider.create


### PR DESCRIPTION
Thanks to @h0tw1r3 and his initial work on this.  I've expanded on it to fix bugs I found and make it work with Puppet 7 agents.

On the server side, I've only tested puppetserver 6, (but I think it should be fine for Puppet 7 and _probably_ even Puppet 5 users).

On the agent side, there's as much compatibility as possible.  Perhaps in a later release, this could be stripped out, but I _really_ need at least one version released that supports some really old agents running really old ruby. :(

Places I've tested and got this working

- Puppet 3.8.7, Ruby 2.0.0 on Solaris 10 (!!!)
- AIO Puppet 5 on Solaris 10 and Solaris 11
- AIO Puppet 6 on CentOS 6 and CentOS 7
- AIO Puppet 7 on CentOS 7
- `ca_location => true` on Puppetserver 6 (AIO packages on CentOS 7)

`dns_alt_names` tested on Puppet 6 agents.